### PR TITLE
Add find and reverse endian base32 functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
                  / __ |/ __ \_/ ___\_  __ <   |  |\____ \   __\                
                 / /_/ \  ___/\  \___|  | \/\___  ||  |_> >  |                  
                 \____ |\___  >\___  >__|   / ____||   __/|__|                  
-                     \/    \/     \/       \/     |__|v2.3.7                   
+                     \/    \/     \/       \/     |__|v2.3.8                   
                                                                                
                         Original author: Michael Zalewski <mjz@hexize.com>     
                         New maintainer: Gareth Anderson                        
@@ -114,6 +114,18 @@ Returns a string with HTML references like `&gt;` and `&#62;` unescaped to `>`.
 `tr('from', 'to')`
 Takes an argument to translate "from" and an argument of characters to translate "to" and then returns a result with the result (similar to `tr` in Unix).
 
+`rev()`
+Returns the input in reverse order.
+
+`find('subseq', start)`
+Returns the index of a subsequence "subseq" starting at index "start", or `-1` if the subsequence is not found.
+
+`b32re()`
+Returns a reverse-endian base32 decoded string, as used in the SunBurst DGA.  
+
+`b64re()`
+Returns a reverse-endian base64 decoded string.
+
 _Note: you must use **single quotes** around the strings._
 
 # Function Arguments
@@ -184,11 +196,23 @@ New lines can be used to break up command sequences for easier readability.
 ## Reverse the data field
 `... | decrypt field=data rev`
 
+## Find the index of a subsequence in a data field
+`... | decrypt field=data find('subseq', 0)`
+
+## Decrypt SunBurst DGA with reverse endian base32
+`... | decrypt field=data tr('ph2eifo3n5utg1j8d94qrvbmk0sal76c', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567') b32re`
+
 # Contributors
 Shannon Davis (Splunk)
 Steven (malvidin on github)
 
 # Release Notes
+## 2.3.8
+Merged pull request from Steven (malvidin on github)
+
+- New find function
+- New b32re, and b64re functions that use the reverse endian decoding used by the SunBurst DGA
+
 ## 2.3.7
 Merged pull request from Steven (malvidin on github)
 

--- a/app.manifest
+++ b/app.manifest
@@ -5,7 +5,7 @@
     "id": {
       "group": null,
       "name": "decrypt2",
-      "version": "2.3.7"
+      "version": "2.3.8"
     },
     "author": [
       {

--- a/default/app.conf
+++ b/default/app.conf
@@ -3,7 +3,7 @@ id = decrypt2
 
 [install]
 state = enabled
-build = 20210529
+build = 20220429
 
 [ui]
 label = DecryptCommands
@@ -12,5 +12,5 @@ is_visible = false
 [launcher]
 author = Gareth Anderson 
 description = A library of common routines to analyze malware and data exfiltration communications (based on the work of Michael Zalewski).
-version = 2.3.7
+version = 2.3.8
 

--- a/default/searchbnf.conf
+++ b/default/searchbnf.conf
@@ -43,5 +43,5 @@ usage = public
 #tags = searchcommands_app
 #
 [decrypt-options]
-syntax = field=<string> atob | b64 | btoa | b32 | hex | unhex | rol(<int>) | ror(<int>) | rotx('<string>') | xor('<string>') | rc4('<string>') | emit('<string>') | load('<string>') | save('<string>') | substr(<int>, <int>)  | ascii | decode('<string>') | escape | unescape | tr('<string>', '<string>') | rev
+syntax = field=<string> atob | b64 | btoa | b32 | hex | unhex | rol(<int>) | ror(<int>) | rotx('<string>') | xor('<string>') | rc4('<string>') | emit('<string>') | load('<string>') | save('<string>') | substr(<int>, <int>)  | ascii | decode('<string>') | escape | unescape | tr('<string>', '<string>') | rev | find('<string>', <int>) | b32re | b64re
 description = Pass the field name to work with, then the command or command(s) to be used, an emit() option can be passed to choose the field to return, defaults to the field name "decrypted" 


### PR DESCRIPTION
Added a find function.  

Also simplified base64 decoding and fixed substr length for negative indexes. Base32 stricter on its handling of whitespace and padding, so I didn't try fixing that.  I thought about adding an `ord()` function, but `substr` and `hex` can get a value that Splunk can convert into a number.

I'm also trying to fill in the gaps for the sunburst decoder.
https://github.com/malvidin/sunburst_decode/blob/main/bin/sunburst.py

I think the only portion that decrypt2 does not cover is `custom_base32decode()`. If it needs a custom function, I want it to be general enough to potentially apply against future encodings. But it might be out of scope.

```
SunBurst DGA Decoding in Splunk with DECRYPT2:
decode_subs_cipher:
  - decrypt2 tr()
  - rex/replace "s/[-0_.][tio2bcer]/0#/g" (once for each slice mod 4)
  - rex/replace "s/#//g"
  
decode_guid:
  - custom_base32decode
  - decrypt2 store substr[0]
  - decrypt2 store substr[1:]
  - decrypt2 xor
  - decrypt2 hex
  
get_domain_order:
  - decrypt2 store substr[0]
  - decrypt2 store substr[15]
  - decrypt2 find
  - eval tonumber (or decrypt2 ord)
  - eval %

custom_base32decode:
  - TODO - popping bits off the stack
```