### PR TITLE
Clearer Error Handling for Null

### DIFF
--- a/bin/decrypt.py
+++ b/bin/decrypt.py
@@ -2,6 +2,8 @@
 # coding=utf-8
 
 from __future__ import absolute_import, division, print_function, unicode_literals
+
+import csv
 import os
 import sys
 
@@ -19,23 +21,29 @@ class DecryptCommand(StreamingCommand):
     def stream(self, records):
         stmt = " ".join(self.fieldnames)
 
-        for record in records:
-            try:
-                decryptlib.g_record = record
-                decryptlib.logger = self.logger
-                exception_string = None
+        try:
+            for record in records:
+                try:
+                    decryptlib.g_record = record
+                    decryptlib.logger = self.logger
+                    exception_string = None
 
-                if self.field in record:
-                    result = record[self.field]
+                    if self.field in record:
+                        result = record[self.field]
 
-                    for fn, args in decryptlib.parsestmt(stmt):
-                        result = fn(result, args)
+                        for fn, args in decryptlib.parsestmt(stmt):
+                            result = fn(result, args)
 
-            except Exception as e:
-                exception_string = str(e)
-                record[".decrypt_failure__"] = exception_string 
+                except Exception as e:
+                    exception_string = str(e)
+                    record[".decrypt_failure__"] = exception_string
 
-            yield record
+                yield record
+        except csv.Error:
+            raise csv.Error('Splunk record contained NUL. '
+                            'Use eval/replace or sed beforehand to work around, '
+                            'or use the decrypt/escape function in the previous command.'
+                            ' (fixed in Python 3.11)')
 
 
 dispatch(DecryptCommand, sys.argv, sys.stdin, sys.stdout, __name__)

--- a/bin/decrypt.py
+++ b/bin/decrypt.py
@@ -41,7 +41,7 @@ class DecryptCommand(StreamingCommand):
                 yield record
         except csv.Error:
             raise csv.Error('Splunk record contained NUL. '
-                            'Use eval/replace or sed beforehand to work around, '
+                            'Use eval/replace or rex/sed beforehand to work around, '
                             'or use the decrypt/escape function in the previous command.'
                             ' (fixed in Python 3.11)')
 


### PR DESCRIPTION
When Splunk sends a CSV that contains null bytes to Python 3.7, the CSV Reader error is not helpful. This makes the error more clear, although finding the field that contains null bytes will likely be frustrating.