### PR TITLE
Remove Python2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ Outputs the current state as UTF-8 to the field name.
 `substr(offset, count)`
 Returns a substring of the input, starting at the index offset with the number of characters count. Set the count to `'null'` to return from the start offset to the end of the input.
 
+`slice(start, end)`
+Returns a slice of the input, starting at start offset to the end offset. Set the end to `'null'` to go to the end of the input.
+
 `decode('codec')`
 Returns a decoded version of the input based on the codec, python codec list is available on https://docs.python.org/3/library/codecs.html#standard-encodings
 

--- a/default/app.conf
+++ b/default/app.conf
@@ -3,7 +3,7 @@ id = decrypt2
 
 [install]
 state = enabled
-build = 20230605
+build = 20230607
 
 [ui]
 label = DecryptCommands
@@ -12,5 +12,5 @@ is_visible = false
 [launcher]
 author = Gareth Anderson 
 description = A library of common routines to analyze malware and data exfiltration communications (based on the work of Michael Zalewski).
-version = 2.3.14
+version = 2.4.0
 

--- a/default/searchbnf.conf
+++ b/default/searchbnf.conf
@@ -43,5 +43,5 @@ usage = public
 #tags = searchcommands_app
 #
 [decrypt-options]
-syntax = field=<string> atob | b64 | btoa | b32 | b58 | hex | unhex | rol(<int>) | ror(<int>) | rotx('<string>') | xor('<string>') | rc4('<string>') | emit('<string>') | load('<string>') | save('<string>') | substr(<int>, <int>)  | ascii | decode('<string>') | escape | unescape | tr('<string>', '<string>') | rev | find('<string>', <int>) | b32re | b64re | zlib_inflate(<int>)
+syntax = field=<string> atob | b64 | btoa | b32 | b58 | hex | unhex | rol(<int>) | ror(<int>) | rotx('<string>') | xor('<string>') | rc4('<string>') | emit('<string>') | load('<string>') | save('<string>') | substr(<int>, <int>) | slice(<int>, <int>) | ascii | decode('<string>') | escape | unescape | tr('<string>', '<string>') | rev | find('<string>', <int>) | b32re | b64re | zlib_inflate(<int>)
 description = Pass the field name to work with, then the command or command(s) to be used, an emit() option can be passed to choose the field to return, defaults to the field name "decrypted" 


### PR DESCRIPTION
This is a breaking change for those who are using older Splunk versions that do not include Python3 support. Additional is cleanup was done with the Black code formatter for simpler code formatting in the future.

Commas in functions like `substr(1,4)` are not passed to the app. The workaround would be to use `substr(1 "," 4), which is more confusing. Fortunately, `substr(1,4)` is processed as intended, even if `substr(1 4) is the input the app receives in the Tokenizer. 

Added a `slice()` function, since many users are more familiar with it. ECMAScript considers `substr()` deprecated, so a more unambiguous function should be useful. 