### PR TITLE
That fix

### DIFF
--- a/bin/__init__.py
+++ b/bin/__init__.py
@@ -1,0 +1,1 @@
+# this is just here to trick pytest into thinking bin is a package so we can do imports

--- a/bin/decrypt.py
+++ b/bin/decrypt.py
@@ -15,6 +15,8 @@ from splunklib.searchcommands import (
 )
 import decryptlib
 
+FAILURE_FIELD = ".decrypt_failure__"
+
 
 @Configuration()
 class DecryptCommand(StreamingCommand):
@@ -27,11 +29,10 @@ class DecryptCommand(StreamingCommand):
         or option settings prior to execution. It is called during the getinfo exchange before command metadata is sent
         to splunkd.
         """
-
         # this forces the field to exist at the end
         self.configuration.required_fields = [self.field]
-
-        super().prepare()
+        # this means we're only sent the field the user asked for
+        self.configuration.clear_required_fields = True
 
     def stream(self, records):
         stmt = " ".join(self.fieldnames)
@@ -48,7 +49,7 @@ class DecryptCommand(StreamingCommand):
                             result = fn(result, args)
 
                 except Exception as e:
-                    record[".decrypt_failure__"] = str(e)
+                    record[FAILURE_FIELD] = str(e)
 
                 yield record
         except csv.Error:

--- a/bin/decrypt.py
+++ b/bin/decrypt.py
@@ -20,9 +20,21 @@ import decryptlib
 class DecryptCommand(StreamingCommand):
     field = Option(require=False, default="_raw", validate=validators.Fieldname())
 
+    def prepare(self) -> None:
+        """Prepare for execution.
+
+        This method should be overridden in search command classes that wish to examine and update their configuration
+        or option settings prior to execution. It is called during the getinfo exchange before command metadata is sent
+        to splunkd.
+        """
+
+        # this forces the field to exist at the end
+        self.configuration.required_fields = [self.field]
+
+        super().prepare()
+
     def stream(self, records):
         stmt = " ".join(self.fieldnames)
-
         try:
             for record in records:
                 try:
@@ -36,8 +48,7 @@ class DecryptCommand(StreamingCommand):
                             result = fn(result, args)
 
                 except Exception as e:
-                    exception_string = str(e)
-                    record[".decrypt_failure__"] = exception_string
+                    record[".decrypt_failure__"] = str(e)
 
                 yield record
         except csv.Error:

--- a/tests/test_ssc.py
+++ b/tests/test_ssc.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from collections import OrderedDict
+
+# add the bin dir to the path
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_decrypt_hexed() -> None:
+    """this checks the stream function not the rest"""
+    import bin.decrypt as decrypt
+
+    streamer = decrypt.DecryptCommand()
+    """ equivalent to `| decrypt field=testfield hex() emit('hexed')` """
+    streamer.field = "testfield"
+    streamer.fieldnames = ["hex()", "emit('hexed')"]
+
+    records = [
+        OrderedDict([("testfield", "hello"), ("_chunked_idx", "0")]),
+        OrderedDict([("testfield", "world"), ("_chunked_idx", "1")]),
+        OrderedDict([("_chunked_idx", "2")]),
+    ]
+
+    output = list(streamer.stream(records))
+    assert output[0]["testfield"] == "hello"
+    assert output[0]["hexed"] == "68656c6c6f"
+    print(output[0])
+
+    assert output[1]["testfield"] == "world"
+    assert output[1]["hexed"] == "776f726c64"
+    print(output[1])
+
+    assert output[2] == {"_chunked_idx": "2"}
+    print(output[2])
+    assert len(output) == 3
+    # ensure there's no errors
+    assert not any(decrypt.FAILURE_FIELD in rec for rec in output)


### PR DESCRIPTION
Refers #28

Changes:

```python
 self.configuration.required_fields = [self.field]
```

This tells Splunk "no really, I want this field"

```python
self.configuration.clear_required_fields = True
```

.. and only this field!


With pytest installed, `tests/test_ssc.py` will test basic functionality of the `stream()` function and hex-encoding a field.